### PR TITLE
Add --component-name flag to bundle subcommand

### DIFF
--- a/tlmcmddb-cli/src/main.rs
+++ b/tlmcmddb-cli/src/main.rs
@@ -5,7 +5,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use clap::{Parser, Subcommand};
 use tlmcmddb::Database;
 
@@ -24,6 +24,8 @@ enum Command {
         output: PathBuf,
         #[clap(long)]
         pretty: bool,
+        #[clap(long)]
+        component_name: Option<String>,
     },
     Merge {
         #[clap(required = true)]
@@ -140,6 +142,7 @@ fn main() -> Result<()> {
             cmd_db_dir,
             output,
             pretty,
+            component_name,
         } => {
             let mut builder = DatabaseBuilder::default();
             for entry in fs::read_dir(tlm_db_dir)? {
@@ -158,6 +161,10 @@ fn main() -> Result<()> {
                     component,
                     telemetry,
                 } = filename.parse().context(ctx.clone())?;
+                let component = component_name
+                    .clone()
+                    .or(component)
+                    .ok_or_else(|| anyhow!("filename must contain component name"))?;
                 let file = fs::OpenOptions::new()
                     .read(true)
                     .open(entry.path())

--- a/tlmcmddb-csv/src/tlm/filename.rs
+++ b/tlmcmddb-csv/src/tlm/filename.rs
@@ -4,7 +4,7 @@ use anyhow::anyhow;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Filename {
-    pub component: String,
+    pub component: Option<String>,
     pub telemetry: String,
 }
 
@@ -22,11 +22,14 @@ impl FromStr for Filename {
         let telemetry = basename[symbol_index + SYMBOL_TLM_DB.len()..].to_string();
         let head = &basename[..symbol_index];
         let Some(underscore_index) = head.rfind('_') else {
-            return Err(anyhow!("filename must contain component name"));
+            return Ok(Self {
+                component: None,
+                telemetry,
+            });
         };
         let component = head[underscore_index + 1..].to_string();
         Ok(Self {
-            component,
+            component: Some(component),
             telemetry,
         })
     }
@@ -43,7 +46,7 @@ mod tests {
             component,
             telemetry,
         } = hk.parse().unwrap();
-        assert_eq!("MOBC", component);
+        assert_eq!(Some("MOBC"), component.as_deref());
         assert_eq!("HK", telemetry);
     }
 }


### PR DESCRIPTION
To improve customizability of component name, this patch adds a new flag `--component-name flag`.
The component name have to be contained in TLM_DB filename previously, but we sometimes need to rename it in some cases.
This flags is useful in such situation.