### PR TITLE
Bump internal c2a-tlmcmddb deps version to 2.5

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,3 @@
+[patch.crates-io]
+tlmcmddb = { path = "./tlmcmddb" }
+tlmcmddb-csv = { path = "./tlmcmddb-csv" }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 2.5.1 (2023-12-22)
+
+### Internal
+
+- [#37](https://github.com/arkedge/c2a-tlmcmddb/pull/37): Bump internal c2a-tlmcmddb deps version to 2.5
+
+
 ## 2.5.0 (2023-12-22)
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,15 +296,6 @@ dependencies = [
 
 [[package]]
 name = "tlmcmddb"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ad369378cb3161705423ac55a49190816b6044296b576bdf9d7049dba5b9132"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "tlmcmddb"
 version = "2.5.0"
 dependencies = [
  "serde",
@@ -317,20 +308,8 @@ dependencies = [
  "anyhow",
  "clap",
  "serde_json",
- "tlmcmddb 0.2.0",
- "tlmcmddb-csv 0.2.0",
-]
-
-[[package]]
-name = "tlmcmddb-csv"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aca4120f5913a778928421b1fb49296f76765b96627e8efe3e710007e16032f"
-dependencies = [
- "anyhow",
- "csv",
- "serde",
- "tlmcmddb 0.2.0",
+ "tlmcmddb",
+ "tlmcmddb-csv",
 ]
 
 [[package]]
@@ -341,7 +320,7 @@ dependencies = [
  "csv",
  "serde",
  "serde_json",
- "tlmcmddb 0.2.0",
+ "tlmcmddb",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,14 +296,14 @@ dependencies = [
 
 [[package]]
 name = "tlmcmddb"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "tlmcmddb-cli"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -314,7 +314,7 @@ dependencies = [
 
 [[package]]
 name = "tlmcmddb-csv"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "anyhow",
  "csv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "2.5.0"
+version = "2.5.1"
 repository = "https://github.com/arkedge/c2a-tlmcmddb"
 readme = "README.md"
 

--- a/tlmcmddb-cli/Cargo.toml
+++ b/tlmcmddb-cli/Cargo.toml
@@ -12,6 +12,6 @@ readme.workspace = true
 [dependencies]
 anyhow = { version = "1", features = ["backtrace"] }
 clap = { version = "4.4.11", features = ["derive"] }
-tlmcmddb = "0.2.0"
-tlmcmddb-csv = "0.2.0"
+tlmcmddb = "2.5"
+tlmcmddb-csv = "2.5"
 serde_json = "1"

--- a/tlmcmddb-csv/Cargo.toml
+++ b/tlmcmddb-csv/Cargo.toml
@@ -12,7 +12,7 @@ readme.workspace = true
 [dependencies]
 anyhow = "1"
 csv = "1.3.0"
-tlmcmddb = "0.2.0"
+tlmcmddb = "2.5"
 serde = { version = "1.0.193", features = ["derive"] }
 
 [dev-dependencies]


### PR DESCRIPTION
- #32 で内部の crate のバージョンを更新するのを忘れていたので更新
  - c2a-tlmcmddb では `tlm-cmd-db` 側での minor update による parser 側での対応などが見込まれるため，minor version まで指定することとする