### PR TITLE
モデルにDisplayInfoを追加する

### DIFF
--- a/tlmcmddb-csv/src/tlm/body.rs
+++ b/tlmcmddb-csv/src/tlm/body.rs
@@ -413,6 +413,7 @@ impl TryFrom<Line> for model::Field {
             extraction_info,
             conversion_info: conversion_info.try_into()?,
             description: unescape(&line.description),
+            display_info: Default::default(),
             note: unescape(&line.note),
         })
     }

--- a/tlmcmddb/src/tlm.rs
+++ b/tlmcmddb/src/tlm.rs
@@ -64,6 +64,9 @@ pub struct Field {
     /// テレメトリのオクテット列からこのフィールドの値を抜き出す際に必要な情報
     pub extraction_info: FieldExtractionInfo,
     pub conversion_info: ConversionInfo,
+    /// GS SW などでテレメトリを表示するときの情報
+    #[serde(default)]
+    pub display_info: DisplayInfo,
     /// このフィールドの説明（衛星運用者向け）
     pub description: String,
     /// このフィールドの説明（衛星開発者向け）
@@ -197,6 +200,13 @@ impl VariableType {
             VariableType::Uint8 | VariableType::Uint16 | VariableType::Uint32
         )
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct DisplayInfo {
+    pub label: String,
+    pub unit: String,
+    pub format: String,
 }
 
 /// コメント行

--- a/tlmcmddb/src/tlm.rs
+++ b/tlmcmddb/src/tlm.rs
@@ -202,10 +202,15 @@ impl VariableType {
     }
 }
 
+/// GS SW などでテレメトリを表示するときの情報
+/// 各フィールドの具体的な解釈と利用方法は GS SW に依存する
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 pub struct DisplayInfo {
+    /// 表示名
     pub label: String,
+    /// 単位
     pub unit: String,
+    /// フォーマットの指定
     pub format: String,
 }
 


### PR DESCRIPTION
#21 にてパーサのアップデートをしているが
* [A1セルに載る情報](https://github.com/ut-issl/tlm-cmd-db/pull/24#issuecomment-1809525002)が不明
* 正規のV3のcsvファイルがまだない

ため、モデルの変更のみ先にマージする