### PR TITLE
Switch clippy action reviewdog reporter on push

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,9 +37,15 @@ jobs:
         uses: Swatinem/rust-cache@v2.7.1
 
       - name: reviewdog / clippy
+        if: github.event_name == 'pull_request'
         uses: sksat/action-clippy@v0.7.0
         with:
           reporter: github-pr-review
+      - name: reviewdog / clippy
+        if: github.event_name == 'push'
+        uses: sksat/action-clippy@v0.7.0
+        with:
+          reporter: github-check
 
       - name: format
         run: |


### PR DESCRIPTION
- #42 
- `on: push` の際は `github-check` を使うことで reviewdog のエラーが出ないようにします