### PR TITLE
tlmcmddb-cli: Introduce notalawyer to embed license notice into binary

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,6 +13,8 @@ permissions:
 
 env:
   CARGO_INCREMENTAL: 0
+  # renovate: datasource=github-releases depName=EmbarkStudios/cargo-about
+  CARGO_ABOUT_VERSION: 0.6.4
 
 jobs:
   rust:
@@ -35,6 +37,10 @@ jobs:
 
       - name: cache dependencies
         uses: Swatinem/rust-cache@v2.7.5
+
+      - name: install cargo-about
+        run: |
+          cargo install cargo-about --locked --version ${{ env.CARGO_ABOUT_VERSION }}
 
       - name: reviewdog / clippy
         if: github.event_name == 'pull_request'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,6 +208,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "notalawyer"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8f10fae64217fe9e567380c332b648a937db0c756e11a17594bc8a8d5ca7762"
+
+[[package]]
+name = "notalawyer-build"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a23fb327485a4b7e648a4a23053456b400f5d3fed6cb4fc7b4029ac1f6297c8"
+
+[[package]]
+name = "notalawyer-clap"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6e87f4834f3bbf79650765227edffb5b40e96199a7d8ba04e57f433ea867f1e"
+dependencies = [
+ "clap",
+ "notalawyer",
+]
+
+[[package]]
 name = "object"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,6 +330,8 @@ version = "2.5.1"
 dependencies = [
  "anyhow",
  "clap",
+ "notalawyer-build",
+ "notalawyer-clap",
  "serde_json",
  "tlmcmddb",
  "tlmcmddb-csv",

--- a/tlmcmddb-cli/Cargo.toml
+++ b/tlmcmddb-cli/Cargo.toml
@@ -9,9 +9,13 @@ readme.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[build-dependencies]
+notalawyer-build = "0.2"
+
 [dependencies]
 anyhow = { version = "1", features = ["backtrace"] }
 clap = { version = "4.4.11", features = ["derive"] }
 tlmcmddb = "2.5"
 tlmcmddb-csv = "2.5"
 serde_json = "1"
+notalawyer-clap = "0.2"

--- a/tlmcmddb-cli/about.toml
+++ b/tlmcmddb-cli/about.toml
@@ -1,0 +1,5 @@
+accepted = [
+  "MIT",
+  "Apache-2.0",
+  "Unicode-DFS-2016",
+]

--- a/tlmcmddb-cli/build.rs
+++ b/tlmcmddb-cli/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    println!("cargo:rerun-if-changed=Cargo.toml");
+
+    notalawyer_build::build();
+}

--- a/tlmcmddb-cli/src/main.rs
+++ b/tlmcmddb-cli/src/main.rs
@@ -7,6 +7,7 @@ use std::{
 
 use anyhow::{anyhow, Context, Result};
 use clap::{Parser, Subcommand};
+use notalawyer_clap::*;
 use tlmcmddb::Database;
 
 #[derive(Parser)]
@@ -135,7 +136,7 @@ impl DatabaseSet {
 }
 
 fn main() -> Result<()> {
-    let cli = Cli::parse();
+    let cli = Cli::parse_with_license_notice(include_notice!());
     match cli.command {
         Command::Bundle {
             tlm_db_dir,


### PR DESCRIPTION
To prepare for future binary distribution, use [notalawyer](https://github.com/arkedge/notalawyer) to display the binary crate license.

This requires [cargo-about](https://github.com/EmbarkStudios/cargo-about) to be installed before building.

- #56 