### PR TITLE
TLM field group の形式仕様を試す

### DIFF
--- a/formal/README.md
+++ b/formal/README.md
@@ -1,0 +1,40 @@
+# Formal Methods Trial
+
+This directory records a small formal-methods trial for `arkedge/c2a-tlmcmddb`.
+
+The repository was selected from the accessible GitHub repositories because it is
+a Rust data-model and CSV parser for C2A TlmCmd DB.  That shape is a good fit for
+small predicate models: the implementation accepts rows, while downstream
+codegen and operations depend on stronger database invariants.
+
+## Commands
+
+```bash
+sh formal/check.sh
+```
+
+The check currently requires `z3` on `PATH`.
+
+## Models
+
+- `z3/tlm-field-group-contract.smt2`
+  - Source: `tlmcmddb/src/tlm.rs`, `tlmcmddb-csv/src/tlm/body.rs`
+  - Shape: pure predicate over a telemetry field group
+  - Checks: field ranges must be non-empty, fit within the group variable
+    width, not overlap, and multi-field groups must use an unsigned integer
+    variable type.
+
+## Trial Result
+
+The model found three current-parser witnesses that are accepted at the CSV
+shape level but should be domain questions for a TlmCmd DB contract:
+
+1. A multi-field group can use a non-unsigned-integer variable type even though
+   `tlmcmddb/src/tlm.rs` documents that multi-field groups must use
+   `uint8_t`, `uint16_t`, or `uint32_t`.
+2. A field range can exceed the group variable width.
+3. Two field ranges in the same group can overlap.
+
+These are not yet asserted as implementation bugs.  They identify the next
+useful regression guards if the project wants the parser to reject invalid TLM
+DB shapes before codegen or operations consume them.

--- a/formal/check.sh
+++ b/formal/check.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+MODEL="$ROOT_DIR/formal/z3/tlm-field-group-contract.smt2"
+
+if ! command -v z3 >/dev/null 2>&1; then
+  echo "z3 is required for formal checks" >&2
+  exit 1
+fi
+
+actual="$(z3 "$MODEL" | grep -E '^(sat|unsat|unknown)$' | tr '\n' ' ')"
+expected="sat sat sat sat unsat unsat unsat "
+
+if [[ "$actual" != "$expected" ]]; then
+  echo "unexpected z3 result sequence" >&2
+  echo "expected: $expected" >&2
+  echo "actual:   $actual" >&2
+  exit 1
+fi
+
+echo "[ok] z3 formal/z3/tlm-field-group-contract.smt2: $actual"

--- a/formal/z3/tlm-field-group-contract.smt2
+++ b/formal/z3/tlm-field-group-contract.smt2
@@ -1,0 +1,140 @@
+(set-logic QF_LIA)
+(set-option :produce-models true)
+
+; Extracted from:
+; - tlmcmddb/src/tlm.rs
+; - tlmcmddb-csv/src/tlm/body.rs
+;
+; tlm::FieldGroup documents that when a group contains multiple fields, its
+; onboard variable type must be an unsigned integer.  The CSV parser currently
+; builds the data model from rows but does not validate the group-level bit
+; layout.  This finite abstraction uses at most two fields, enough to witness
+; non-unsigned multi-field groups, out-of-width fields, and overlapping fields.
+(declare-const fieldCount Int)
+(declare-const variableBitWidth Int)
+(declare-const variableIsUnsignedInteger Bool)
+(declare-const field1Start Int)
+(declare-const field1Length Int)
+(declare-const field2Start Int)
+(declare-const field2Length Int)
+
+(assert (or (= fieldCount 1) (= fieldCount 2)))
+(assert (or (= variableBitWidth 8)
+            (= variableBitWidth 16)
+            (= variableBitWidth 32)
+            (= variableBitWidth 64)))
+
+; Rust usize deserialization already prevents negative positions and lengths.
+(assert (>= field1Start 0))
+(assert (>= field1Length 0))
+(assert (>= field2Start 0))
+(assert (>= field2Length 0))
+
+; Only uint8_t/uint16_t/uint32_t are unsigned integer variable types in the data
+; model.  float/double and signed integers are represented by
+; variableIsUnsignedInteger = false in this abstraction.
+(assert (=> variableIsUnsignedInteger
+            (or (= variableBitWidth 8)
+                (= variableBitWidth 16)
+                (= variableBitWidth 32))))
+
+(define-fun RangeValid ((start Int) (len Int)) Bool
+  (and (> len 0)
+       (<= (+ start len) variableBitWidth)))
+
+(define-fun RangesOverlap () Bool
+  (and (< field1Start (+ field2Start field2Length))
+       (< field2Start (+ field1Start field1Length))))
+
+; Given a row that deserializes and satisfies conversion-info checks, the current
+; parser has no extra group-level range validation.
+(define-fun CurrentParserAccepts () Bool true)
+
+; Candidate domain contract for safe field-group extraction/codegen.
+(define-fun CandidateAccepts () Bool
+  (and (RangeValid field1Start field1Length)
+       (or (= fieldCount 1)
+           (and variableIsUnsignedInteger
+                (RangeValid field2Start field2Length)
+                (not RangesOverlap)))))
+
+; 1. Current parser can accept a multi-field group whose variable type is not an
+; unsigned integer, even though the data-model comment says it should be.
+(push)
+(assert (= fieldCount 2))
+(assert (= variableBitWidth 16))
+(assert (not variableIsUnsignedInteger))
+(assert (= field1Start 0))
+(assert (= field1Length 8))
+(assert (= field2Start 8))
+(assert (= field2Length 8))
+(assert CurrentParserAccepts)
+(assert (not CandidateAccepts))
+(check-sat)
+(get-model)
+(pop)
+
+; 2. Current parser can accept a field that extends beyond the variable width.
+(push)
+(assert (= fieldCount 1))
+(assert (= variableBitWidth 8))
+(assert (not variableIsUnsignedInteger))
+(assert (= field1Start 7))
+(assert (= field1Length 2))
+(assert CurrentParserAccepts)
+(assert (not CandidateAccepts))
+(check-sat)
+(get-model)
+(pop)
+
+; 3. Current parser can accept overlapping fields in the same group.
+(push)
+(assert (= fieldCount 2))
+(assert (= variableBitWidth 8))
+(assert variableIsUnsignedInteger)
+(assert (= field1Start 0))
+(assert (= field1Length 4))
+(assert (= field2Start 3))
+(assert (= field2Length 4))
+(assert RangesOverlap)
+(assert CurrentParserAccepts)
+(assert (not CandidateAccepts))
+(check-sat)
+(get-model)
+(pop)
+
+; 4. Sanity: the candidate contract accepts a single scalar field that exactly
+; fills a signed or floating-point width.
+(push)
+(assert (= fieldCount 1))
+(assert (= variableBitWidth 32))
+(assert (not variableIsUnsignedInteger))
+(assert (= field1Start 0))
+(assert (= field1Length 32))
+(assert CandidateAccepts)
+(check-sat)
+(get-model)
+(pop)
+
+; 5. Candidate multi-field groups never overlap.
+(push)
+(assert (= fieldCount 2))
+(assert CandidateAccepts)
+(assert RangesOverlap)
+(check-sat)
+(pop)
+
+; 6. Candidate accepted field1 never exceeds the group variable width.
+(push)
+(assert CandidateAccepts)
+(assert (> (+ field1Start field1Length) variableBitWidth))
+(check-sat)
+(pop)
+
+; 7. Candidate multi-field groups require an unsigned integer variable type.
+(push)
+(assert (= fieldCount 2))
+(assert (not variableIsUnsignedInteger))
+(assert CandidateAccepts)
+(check-sat)
+(pop)


### PR DESCRIPTION
## 概要

`tlmcmddb` / `tlmcmddb-csv` の TLM field group について、Z3 による小さな形式モデルを追加します。

この repo は C2A TlmCmd DB の data model / CSV parser で、CSV として受け入れる条件と、codegen / 運用 DB として安全に扱うための不変条件が分かれやすいため、形式手法の試行対象にしました。

## モデル化した仕様候補

対象:

- `tlmcmddb/src/tlm.rs`
- `tlmcmddb-csv/src/tlm/body.rs`

候補仕様:

- field range は 0 bit より大きい
- field range は group variable width を超えない
- 同一 field group 内の field range は重ならない
- 複数 field を持つ group は `uint8_t` / `uint16_t` / `uint32_t` の unsigned integer variable type を使う

## Z3 で見つかった witness

現在の parser は CSV row が deserialize でき、conversion info が妥当なら group-level bit layout までは検証しません。そのため、次の shape は current parser では受け入れ得ます。

1. 複数 field group なのに unsigned integer ではない variable type を使う
2. field range が variable width を超える
3. 同一 group の field range が重なる

これはまだ実装バグ確定ではなく、TlmCmd DB 契約として parser が拒否すべきかを決めるための domain question です。

## 検証

- `sh formal/check.sh`
- `cargo test -p tlmcmddb -p tlmcmddb-csv`

補足: workspace 全体の `cargo test` は、既存の `tlmcmddb-cli` build script が `cargo about` を要求するため、手元では `error: no such command: about` で止まります。今回の変更対象である `tlmcmddb` / `tlmcmddb-csv` は通しています。